### PR TITLE
Add headers for mentioned flags resp. macros

### DIFF
--- a/include/libmnlxt/rt_addr.h
+++ b/include/libmnlxt/rt_addr.h
@@ -11,9 +11,10 @@
 #ifndef LIBMNLXT_RT_ADDR_H_
 #define LIBMNLXT_RT_ADDR_H_
 
-#include <linux/if_addr.h>
 #include <netinet/in.h>
-#include <sys/socket.h>
+
+#include <linux/if_addr.h>
+#include <linux/rtnetlink.h>
 
 #include <libmnlxt/data.h>
 
@@ -44,7 +45,7 @@ typedef struct {
 	uint8_t family;
 	/** IPv4/IPv6 prefix length */
 	uint8_t prefixlen;
-	/** Interface address flags
+	/** Interface address flags, see linux/if_addr.h
 	 * IFA_F_TEMPORARY
 	 * IFA_F_DEPRECATED
 	 * IFA_F_TENTATIVE

--- a/include/libmnlxt/rt_link.h
+++ b/include/libmnlxt/rt_link.h
@@ -13,6 +13,9 @@
 
 #include <net/ethernet.h>
 #include <net/if.h>
+#include <net/if_arp.h>
+
+#include <linux/if.h>
 
 #include <libmnlxt/data.h>
 
@@ -68,7 +71,7 @@ typedef struct {
 	 */
 	uint16_t type;
 	uint8_t family;
-	/** link state, see RFC2863
+	/** link state, see linux/if.h, RFC2863
 	 * IF_OPER_UNKNOWN
 	 * IF_OPER_NOTPRESENT
 	 * IF_OPER_DOWN

--- a/include/libmnlxt/rt_route.h
+++ b/include/libmnlxt/rt_route.h
@@ -11,8 +11,6 @@
 #ifndef LIBMNLXT_RT_ROUTE_H_
 #define LIBMNLXT_RT_ROUTE_H_
 
-#include <sys/socket.h>
-
 #include <libmnlxt/rt_addr.h>
 
 typedef enum {

--- a/include/libmnlxt/rt_rule.h
+++ b/include/libmnlxt/rt_rule.h
@@ -11,7 +11,7 @@
 #ifndef LIBMNLXT_RT_RULE_H_
 #define LIBMNLXT_RT_RULE_H_
 
-#include <sys/socket.h>
+#include <linux/fib_rules.h>
 
 #include <libmnlxt/rt_addr.h>
 
@@ -45,7 +45,7 @@ typedef struct {
 	 * */
 	uint8_t table;
 	uint8_t tos;
-	/** Rule actions
+	/** Rule actions, see linux/fib_rules.h
 	 * FR_ACT_UNSPEC
 	 * FR_ACT_TO_TBL			pass to fixed table
 	 * FR_ACT_GOTO				jump to another rule

--- a/src/rtnl/rule_data.c
+++ b/src/rtnl/rule_data.c
@@ -9,7 +9,6 @@
  */
 
 #include <errno.h>
-#include <linux/fib_rules.h>
 #include <string.h>
 
 #include <libmnlxt/rt.h>

--- a/src/xfrm/policy.c
+++ b/src/xfrm/policy.c
@@ -9,10 +9,8 @@
  */
 
 #include <errno.h>
-#include <netinet/in.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/socket.h>
 
 #include <libmnlxt/xfrm_policy.h>
 

--- a/src/xfrm/policy_data.c
+++ b/src/xfrm/policy_data.c
@@ -9,7 +9,6 @@
  */
 
 #include <errno.h>
-#include <netinet/in.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/tests/rtnl/rtnl_addr_mod.c
+++ b/tests/rtnl/rtnl_addr_mod.c
@@ -8,13 +8,13 @@
  *
  */
 
-#include <arpa/inet.h>
-#include <net/if.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include "../../include/libmnlxt/mnlxt.h"
+#include <arpa/inet.h>
+
+#include <libmnlxt/mnlxt.h>
 
 int validate_ip_prefix(mnlxt_inet_addr_t *ipaddr, int *prefix, int *family, const char *ipstr, const char *prefixstr) {
 	int rc = -1;

--- a/tests/rtnl/rtnl_dump.c
+++ b/tests/rtnl/rtnl_dump.c
@@ -8,13 +8,11 @@
  *
  */
 
-#include <arpa/inet.h>
 #include <errno.h>
-#include <netinet/in.h>
 #include <stdio.h>
-#include <sys/socket.h>
 
-#include "../../include/libmnlxt/mnlxt.h"
+#include <libmnlxt/mnlxt.h>
+
 #include "rtnl_common.h"
 
 static int test_addr_dump() {

--- a/tests/rtnl/rtnl_linkaddr_get.c
+++ b/tests/rtnl/rtnl_linkaddr_get.c
@@ -9,7 +9,6 @@
  */
 
 #include <arpa/inet.h>
-#include <net/if.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/tests/xfrm/xfrm_dump.c
+++ b/tests/xfrm/xfrm_dump.c
@@ -10,9 +10,7 @@
 
 #include <arpa/inet.h>
 #include <errno.h>
-#include <netinet/in.h>
 #include <stdio.h>
-#include <sys/socket.h>
 
 #include <libmnlxt/mnlxt.h>
 

--- a/tests/xfrm/xfrm_policy_mod.c
+++ b/tests/xfrm/xfrm_policy_mod.c
@@ -9,12 +9,11 @@
  */
 
 #include <arpa/inet.h>
-#include <net/if.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include "../../include/libmnlxt/mnlxt.h"
+#include <libmnlxt/mnlxt.h>
 
 static void usage(const char *progname) {
 	printf("usage: %s add|del\n", progname);


### PR DESCRIPTION
Some headers were added or moved to give user direct access to mentioned flags inside header files. It is also important to keep an eye on include order. Subfolders of net or netinet must be prioritized before headers from linux are included. This is to avoid collisions / redeclaration of same namespace like "net/if.h" and "linux/if.h".