### PR TITLE
rt link bug fixes

### DIFF
--- a/src/rtnl/addr_data.c
+++ b/src/rtnl/addr_data.c
@@ -92,8 +92,8 @@ int mnlxt_rt_addr_compare(const mnlxt_rt_addr_t *rt_addr1, const mnlxt_rt_addr_t
 	if (NULL == rt_addr1 || NULL == rt_addr2) {
 		errno = EINVAL;
 	} else {
-		for (i = 0; i < MNLXT_RT_ADDR_MAX; ++i) {
-			uint64_t flag = MNLXT_FLAG(i);
+		uint64_t flag = 1;
+		for (i = 0; i < MNLXT_RT_ADDR_MAX; ++i, flag <<= 1) {
 			if (0 == (flag & filter)) {
 				continue;
 			}
@@ -139,9 +139,9 @@ int mnlxt_rt_addr_put(struct nlmsghdr *nlh, const mnlxt_rt_addr_t *addr) {
 	if (addr && nlh) {
 		struct ifaddrmsg *ifam = mnl_nlmsg_put_extra_header(nlh, sizeof(struct ifaddrmsg));
 		int i;
-		int flag = 0x1;
+		uint16_t flag = 1;
 		size_t addr_size = (AF_INET == addr->family ? sizeof(addr->addr.in) : sizeof(addr->addr));
-		for (i = 0; i < MNLXT_RT_ADDR_MAX; ++i) {
+		for (i = 0; i < MNLXT_RT_ADDR_MAX; ++i, flag <<= 1) {
 			if (addr->prop_flags & flag) {
 				switch (i) {
 				case MNLXT_RT_ADDR_FAMILY:
@@ -176,7 +176,6 @@ int mnlxt_rt_addr_put(struct nlmsghdr *nlh, const mnlxt_rt_addr_t *addr) {
 					break;
 				}
 			}
-			flag <<= 1;
 		}
 		rc = 0;
 	} else {

--- a/src/rtnl/link.c
+++ b/src/rtnl/link.c
@@ -223,6 +223,7 @@ static int mnlxt_rt_link_set_selected_flags(mnlxt_rt_link_t *rt_link, uint32_t f
 		}
 		rt_link->flag_mask |= flags;
 		MNLXT_SET_PROP_FLAG(rt_link, MNLXT_RT_LINK_FLAGS);
+		rc = 0;
 	}
 	return rc;
 }

--- a/src/rtnl/link_data.c
+++ b/src/rtnl/link_data.c
@@ -229,6 +229,8 @@ int mnlxt_rt_link_match(const mnlxt_rt_link_t *rt_link, const mnlxt_rt_link_t *m
 		rc = mnlxt_rt_link_compare(rt_link, match, match->prop_flags);
 		if (0 == rc && MNLXT_GET_PROP_FLAG(match, MNLXT_RT_LINK_INFO)) {
 			rc = mnlxt_rt_link_info_cmp(&rt_link->info, &match->info, match->info.prop_flags);
+			if (0 < rc)
+				rc = MNLXT_RT_LINK_INFO + 1;
 		}
 	}
 	return rc;

--- a/src/rtnl/link_data.c
+++ b/src/rtnl/link_data.c
@@ -27,7 +27,7 @@ static int mnlxt_rt_link_vlan_cmp(const mnlxt_rt_link_vlan_t *vlan1, uint16_t vl
 		errno = EINVAL;
 	} else {
 		int flag = 0x1;
-		for (i = 0; i < MNLXT_RT_LINK_VLAN_MAX; ++i) {
+		for (i = 0; i < MNLXT_RT_LINK_VLAN_MAX; ++i, flag <<= 1) {
 			if (0 == (flag & filter)) {
 				continue;
 			}
@@ -63,7 +63,7 @@ static int mnlxt_rt_link_xfrm_match(const mnlxt_rt_link_xfrm_t *xfrm1, uint16_t 
 		errno = EINVAL;
 	} else {
 		int flag = 0x1;
-		for (i = 0; i < MNLXT_RT_LINK_XFRM_MAX; ++i) {
+		for (i = 0; i < MNLXT_RT_LINK_XFRM_MAX; ++i, flag <<= 1) {
 			if (0 == (flag & filter)) {
 				continue;
 			}

--- a/src/rtnl/link_data.c
+++ b/src/rtnl/link_data.c
@@ -56,8 +56,8 @@ static int mnlxt_rt_link_vlan_cmp(const mnlxt_rt_link_vlan_t *vlan1, uint16_t vl
 	return i;
 }
 
-static int mnlxt_rt_link_xfrm_match(const mnlxt_rt_link_xfrm_t *xfrm1, uint16_t xfrm_flags1,
-																		const mnlxt_rt_link_xfrm_t *xfrm2, uint16_t xfrm_flags2, uint16_t filter) {
+static int mnlxt_rt_link_xfrm_cmp(const mnlxt_rt_link_xfrm_t *xfrm1, uint16_t xfrm_flags1,
+																	const mnlxt_rt_link_xfrm_t *xfrm2, uint16_t xfrm_flags2, uint16_t filter) {
 	int i = -1;
 	if (NULL == xfrm1 || NULL == xfrm2) {
 		errno = EINVAL;
@@ -120,8 +120,8 @@ static int mnlxt_rt_link_info_cmp(const mnlxt_rt_link_info_t *link_info1, const 
 			/*TODO*/ rc = 0;
 			break;
 		case MNLXT_RT_LINK_INFO_KIND_XFRM:
-			rc = mnlxt_rt_link_xfrm_match(&link_info1->data.xfrm, link_info1->prop_flags, &link_info2->data.xfrm,
-																		link_info2->prop_flags, filter);
+			rc = mnlxt_rt_link_xfrm_cmp(&link_info1->data.xfrm, link_info1->prop_flags, &link_info2->data.xfrm,
+																	link_info2->prop_flags, filter);
 			break;
 		}
 	}

--- a/src/rtnl/link_data.c
+++ b/src/rtnl/link_data.c
@@ -26,7 +26,7 @@ static int mnlxt_rt_link_vlan_cmp(const mnlxt_rt_link_vlan_t *vlan1, uint16_t vl
 	if (NULL == vlan1 || NULL == vlan2) {
 		errno = EINVAL;
 	} else {
-		int flag = 0x1;
+		uint16_t flag = 1;
 		for (i = 0; i < MNLXT_RT_LINK_VLAN_MAX; ++i, flag <<= 1) {
 			if (0 == (flag & filter)) {
 				continue;
@@ -62,7 +62,7 @@ static int mnlxt_rt_link_xfrm_match(const mnlxt_rt_link_xfrm_t *xfrm1, uint16_t 
 	if (NULL == xfrm1 || NULL == xfrm2) {
 		errno = EINVAL;
 	} else {
-		int flag = 0x1;
+		uint16_t flag = 1;
 		for (i = 0; i < MNLXT_RT_LINK_XFRM_MAX; ++i, flag <<= 1) {
 			if (0 == (flag & filter)) {
 				continue;
@@ -239,8 +239,8 @@ int mnlxt_rt_link_compare(const mnlxt_rt_link_t *rt_link1, const mnlxt_rt_link_t
 	if (NULL == rt_link1 || NULL == rt_link2) {
 		errno = EINVAL;
 	} else {
-		for (i = 0; i < MNLXT_RT_LINK_MAX; ++i) {
-			uint64_t flag = MNLXT_FLAG(i);
+		uint64_t flag = 1;
+		for (i = 0; i < MNLXT_RT_LINK_MAX; ++i, flag <<= 1) {
 			if (0 == (flag & filter)) {
 				continue;
 			}
@@ -310,9 +310,9 @@ int mnlxt_rt_link_put(struct nlmsghdr *nlh, const mnlxt_rt_link_t *link) {
 	int rc = -1;
 	if (link && nlh) {
 		struct ifinfomsg *ifm = mnl_nlmsg_put_extra_header(nlh, sizeof(struct ifinfomsg));
-		int flag = 0x1;
+		uint16_t flag = 1;
 		int i = 0;
-		for (; i < MNLXT_RT_LINK_MAX; ++i) {
+		for (; i < MNLXT_RT_LINK_MAX; ++i, flag <<= 1) {
 			if (link->prop_flags & flag) {
 				switch (i) {
 				case MNLXT_RT_LINK_TYPE:
@@ -351,7 +351,6 @@ int mnlxt_rt_link_put(struct nlmsghdr *nlh, const mnlxt_rt_link_t *link) {
 					break;
 				}
 			}
-			flag <<= 1;
 		}
 		rc = 0;
 	} else {

--- a/src/rtnl/route_data.c
+++ b/src/rtnl/route_data.c
@@ -107,8 +107,8 @@ int mnlxt_rt_route_compare(const mnlxt_rt_route_t *rt_route1, const mnlxt_rt_rou
 	if (NULL == rt_route1 || NULL == rt_route2) {
 		errno = EINVAL;
 	} else {
-		for (i = 0; i < MNLXT_RT_ROUTE_MAX; ++i) {
-			uint64_t flag = MNLXT_FLAG(i);
+		uint64_t flag = 1;
+		for (i = 0; i < MNLXT_RT_ROUTE_MAX; ++i, flag <<= 1) {
 			if (0 == (flag & filter)) {
 				continue;
 			}
@@ -153,10 +153,10 @@ int mnlxt_rt_route_put(struct nlmsghdr *nlh, const mnlxt_rt_route_t *route) {
 	int rc = -1;
 	if (route && nlh) {
 		struct rtmsg *rtm = mnl_nlmsg_put_extra_header(nlh, sizeof(struct rtmsg));
-		int flag = 0x1;
+		uint32_t flag = 1;
 		size_t family_size = (AF_INET == route->family ? sizeof(route->src.in) : sizeof(route->src));
 		int i = 0;
-		for (; i < MNLXT_RT_ROUTE_MAX; ++i) {
+		for (; i < MNLXT_RT_ROUTE_MAX; ++i, flag <<= 1) {
 			if (route->prop_flags & flag) {
 				switch (i) {
 				case MNLXT_RT_ROUTE_FAMILY:
@@ -200,7 +200,6 @@ int mnlxt_rt_route_put(struct nlmsghdr *nlh, const mnlxt_rt_route_t *route) {
 					break;
 				}
 			}
-			flag <<= 1;
 		}
 		rc = 0;
 	} else {

--- a/src/rtnl/rule_data.c
+++ b/src/rtnl/rule_data.c
@@ -106,8 +106,8 @@ int mnlxt_rt_rule_compare(const mnlxt_rt_rule_t *rt_rule1, const mnlxt_rt_rule_t
 	if (NULL == rt_rule1 || NULL == rt_rule2) {
 		errno = EINVAL;
 	} else {
-		for (i = 0; i < MNLXT_RT_RULE_MAX; ++i) {
-			uint64_t flag = MNLXT_FLAG(i);
+		uint64_t flag = 1;
+		for (i = 0; i < MNLXT_RT_RULE_MAX; ++i, flag <<= 1) {
 			if (0 == (flag & filter)) {
 				continue;
 			}
@@ -152,10 +152,10 @@ int mnlxt_rt_rule_put(struct nlmsghdr *nlh, const mnlxt_rt_rule_t *rule) {
 	int rc = -1;
 	if (rule && nlh) {
 		struct fib_rule_hdr *rule_hdr = mnl_nlmsg_put_extra_header(nlh, sizeof(struct fib_rule_hdr));
-		int flag = 0x1;
+		uint16_t flag = 1;
 		size_t addr_size = (AF_INET == rule->family ? sizeof(rule->src.in) : sizeof(rule->src));
 		int i = 0;
-		for (; i < MNLXT_RT_RULE_MAX; ++i) {
+		for (; i < MNLXT_RT_RULE_MAX; ++i, flag <<= 1) {
 			if (rule->prop_flags & flag) {
 				switch (i) {
 				case MNLXT_RT_RULE_FAMILY:
@@ -199,7 +199,6 @@ int mnlxt_rt_rule_put(struct nlmsghdr *nlh, const mnlxt_rt_rule_t *rule) {
 					break;
 				}
 			}
-			flag <<= 1;
 		}
 		rc = 0;
 	} else {

--- a/src/xfrm/policy_data.c
+++ b/src/xfrm/policy_data.c
@@ -117,8 +117,8 @@ int mnlxt_xfrm_policy_compare(const mnlxt_xfrm_policy_t *policy1, const mnlxt_xf
 	if (NULL == policy1 || NULL == policy2) {
 		errno = EINVAL;
 	} else {
-		for (i = 0; i < MNLXT_XFRM_POLICY_MAX; ++i) {
-			uint64_t flag = MNLXT_FLAG(i);
+		uint64_t flag = 1;
+		for (i = 0; i < MNLXT_XFRM_POLICY_MAX; ++i, flag <<= 1) {
 			if (0 == (flag & filter)) {
 				continue;
 			}
@@ -188,9 +188,9 @@ int mnlxt_xfrm_policy_put(struct nlmsghdr *nlh, const mnlxt_xfrm_policy_t *polic
 		goto failed;
 	}
 	int i;
-	int flag = 0x1;
+	uint16_t flag = 1;
 	size_t addr_size = (AF_INET == policy->family ? sizeof(policy->src.addr.in) : sizeof(policy->src.addr));
-	for (i = 0; i < MNLXT_XFRM_POLICY_MAX; ++i) {
+	for (i = 0; i < MNLXT_XFRM_POLICY_MAX; ++i, flag <<= 1) {
 		if (policy->prop_flags & flag) {
 			switch (i) {
 			case MNLXT_XFRM_POLICY_FAMILY:
@@ -248,7 +248,6 @@ int mnlxt_xfrm_policy_put(struct nlmsghdr *nlh, const mnlxt_xfrm_policy_t *polic
 				break;
 			}
 		}
-		flag <<= 1;
 	}
 	rc = 0;
 failed:


### PR DESCRIPTION
Some fixes were applied to rt_link module:

- Fix unexpected return value of mnlxt_rt_link_set_selected_flags function.
- Fix selecting flag inside rt_link_vlan_cmp and rt_link_xfrm_match functions.
- Unify selection flag and data type
- Rename function mnlxt_rt_link_xfrm_match to mnlxt_rt_link_xfrm_cmp
- Avoid overlapping of info kind index inside mnlxt_rt_link_match function.