### PR TITLE
fix stringop-truncation errors

### DIFF
--- a/src/rtnl/addr.c
+++ b/src/rtnl/addr.c
@@ -271,7 +271,7 @@ int mnlxt_rt_addr_get_label(const mnlxt_rt_addr_t *addr, mnlxt_if_name_t label) 
 	} else if (!MNLXT_GET_PROP_FLAG(addr, MNLXT_RT_ADDR_LABEL) || NULL == addr->label) {
 		rc = 1;
 	} else {
-		strncpy(label, addr->label, sizeof(mnlxt_if_name_t));
+		*stpncpy(label, addr->label, sizeof(mnlxt_if_name_t)) = '\0';
 		rc = 0;
 	}
 	return rc;

--- a/src/rtnl/rule.c
+++ b/src/rtnl/rule.c
@@ -260,7 +260,7 @@ int mnlxt_rt_rule_get_iif_name(const mnlxt_rt_rule_t *rule, mnlxt_if_name_t iif_
 	} else if (!MNLXT_GET_PROP_FLAG(rule, MNLXT_RT_RULE_IIFNAME) || NULL == rule->iif_name) {
 		rc = 1;
 	} else {
-		strncpy(iif_name, rule->iif_name, sizeof(mnlxt_if_name_t));
+		*stpncpy(iif_name, rule->iif_name, sizeof(mnlxt_if_name_t)) = '\0';
 		rc = 0;
 	}
 	return rc;
@@ -289,7 +289,7 @@ int mnlxt_rt_rule_get_oif_name(const mnlxt_rt_rule_t *rule, mnlxt_if_name_t oif_
 	} else if (!MNLXT_GET_PROP_FLAG(rule, MNLXT_RT_RULE_OIFNAME) || NULL == rule->oif_name) {
 		rc = 1;
 	} else {
-		strncpy(oif_name, rule->oif_name, sizeof(mnlxt_if_name_t));
+		*stpncpy(oif_name, rule->oif_name, sizeof(mnlxt_if_name_t)) = '\0';
 		rc = 0;
 	}
 	return rc;


### PR DESCRIPTION
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I.. -I../include -I../include -I. -g -O2 -Wall -Werror -MT rtnl/libmnlxt_la-addr.lo -MD -MP -MF rtnl/.deps/libmnlxt_la-addr.Tpo -c rtnl/addr.c  -fPIC -DPIC -o rtnl/.libs/libmnlxt_la-addr.o
In file included from /usr/include/string.h:519,
                 from rtnl/addr.c:13:
In function ‘strncpy’,
    inlined from ‘mnlxt_rt_addr_get_label’ at rtnl/addr.c:274:3:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:95:10: error: ‘__builtin_strncpy’ specified bound 16 equals destination size [-Werror=stringop-truncation]
   95 |   return __builtin___strncpy_chk (__dest, __src, __len,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   96 |                                   __glibc_objsize (__dest));
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors

libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I.. -I../include -I../include -I. -g -O2 -Wall -Werror -MT rtnl/libmnlxt_la-rule.lo -MD -MP -MF rtnl/.deps/libmnlxt_la-rule.Tpo -c rtnl/rule.c  -fPIC -DPIC -o rtnl/.libs/libmnlxt_la-rule.o
In file included from /usr/include/string.h:519,
                 from rtnl/rule.c:13:
In function ‘strncpy’,
    inlined from ‘mnlxt_rt_rule_get_iif_name’ at rtnl/rule.c:263:3:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:95:10: error: ‘__builtin_strncpy’ specified bound 16 equals destination size [-Werror=stringop-truncation]
   95 |   return __builtin___strncpy_chk (__dest, __src, __len,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   96 |                                   __glibc_objsize (__dest));
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘mnlxt_rt_rule_get_oif_name’ at rtnl/rule.c:292:3:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:95:10: error: ‘__builtin_strncpy’ specified bound 16 equals destination size [-Werror=stringop-truncation]
   95 |   return __builtin___strncpy_chk (__dest, __src, __len,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   96 |                                   __glibc_objsize (__dest));
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors